### PR TITLE
Merge reed-solomon error correction into master branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "flexi_logger",
  "flume",
  "log",
+ "net",
  "openh264",
  "openh264-sys2",
  "parking_lot 0.12.1",
@@ -680,6 +681,12 @@ checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1419,6 +1426,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "net"
+version = "0.1.0"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +1948,18 @@ dependencies = [
  "itertools",
  "static_init",
  "thiserror",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cb67f1b04dc9e370f3c6653fd4cd152c65afb8ebf52074934369e05ccec20e"
+dependencies = [
+ "bytemuck",
+ "fixedbitset",
+ "once_cell",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -2115,19 +2144,22 @@ name = "server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "bytes",
  "cudarc",
  "dcv-color-primitives",
  "flexi_logger",
  "flume",
  "image",
+ "lazy_static",
  "libc",
  "log",
+ "net",
  "nvidia-video-codec-sdk",
  "openh264",
  "openh264-sys2",
  "rand",
- "reed-solomon-novelpoly",
+ "reed-solomon-simd",
  "ring",
  "rtp",
  "screenshots",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,12 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "log",
+ "rtp",
+]
 
 [[package]]
 name = "nix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pollster",
  "reed-solomon-novelpoly",
+ "reed-solomon-simd",
  "rtp",
  "socket2",
  "statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ exclude = ["openh264-rs"]
 members = [
     "server",
     "client",
+    "net",
     "statistics"
 ]
 

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -3,4 +3,5 @@ out*
 statout
 <<<<<<< HEAD
 *.264
+*.h264
 *.sdp

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 flexi_logger = "0.27"
 
 # Decoding
+reed-solomon-simd = "2.2"
 dcv-color-primitives = "0.6"
 openh264 = { path = "../openh264-rs/openh264" , features = ["decoder", "backtrace"] }
 openh264-sys2 = { path = "../openh264-rs/openh264-sys2" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,3 +37,6 @@ parking_lot = "0.12"
 
 # Stats
 statistics = { path = "../statistics" }
+
+# Net
+net = { path = "../net" }

--- a/client/src/decoder/network.rs
+++ b/client/src/decoder/network.rs
@@ -12,12 +12,12 @@ pub struct LVNetwork {
 }
 
 #[derive(Clone)]
-pub struct LVPacket {
+pub struct LVPacketHolder {
     pub payload: BytesMut,
     pub amt: usize,
 }
 
-impl Default for LVPacket {
+impl Default for LVPacketHolder {
     fn default() -> Self {
         Self {
             payload: {
@@ -37,7 +37,7 @@ impl LVNetwork {
         }
     }
 
-    pub fn run(&self, packet_push: Sender<LVPacket>) {
+    pub fn run(&self, packet_push: Sender<LVPacketHolder>) {
         let addr = self.addr.clone();
         thread::Builder::new()
             .name("network_thread".to_string())
@@ -51,7 +51,7 @@ impl LVNetwork {
     }
 
     fn socket_loop(
-        packet_push: Sender<LVPacket>,
+        packet_push: Sender<LVPacketHolder>,
         addr: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let sock = UdpSocket::bind(addr)?;

--- a/client/src/decoder/video.rs
+++ b/client/src/decoder/video.rs
@@ -215,7 +215,7 @@ impl LVDecoder {
         let mut width: u32 = 0;
         let mut height: u32 = 0;
 
-        let mut lvheader_prev_fragment_index: u32 = 2;
+        let mut lvheader_prev_fragment_index: u32 = EC_RATIO_REGULAR_PACKETS - 1;
 
         let mut rs_decoder = ReedSolomonDecoder::new(
             EC_RATIO_REGULAR_PACKETS as usize,
@@ -304,8 +304,10 @@ impl LVDecoder {
                         }
                     }
 
-                    lvheader_prev_fragment_index = 2;
+                    lvheader_prev_fragment_index = EC_RATIO_REGULAR_PACKETS - 1;
                 }
+
+                debug!("new block, resetting decoder and total packets");
 
                 rs_inorder_packets = 0;
                 rs_recovery_packets = 0;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use decoder::{
-    network::{LVNetwork, LVPacket},
+    network::{LVNetwork, LVPacketHolder},
     video::LVDecoder,
 };
 use double_buffer::DoubleBuffer;
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let db_ui = db.clone();
 
             // Set up mpsc
-            let (pkt_push, pkt_recv) = thingbuf::mpsc::blocking::channel::<LVPacket>(1000);
+            let (pkt_push, pkt_recv) = thingbuf::mpsc::blocking::channel::<LVPacketHolder>(1000);
 
             let receiver = LVNetwork::new(&addr);
             let decoder = LVDecoder::new();

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "net"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rtp = "0.9.0"
+bytes = "1"
+log = "0.4"
+# laziness
+byteorder = "1.5.0"

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod packet;

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -3,6 +3,13 @@ use std::mem::size_of;
 use bytes::BufMut;
 use log::trace;
 
+const MTU_SIZE: usize = 1200;
+const EC_RATIO_RECOVERY_PACKETS: u32 = 1;
+const EC_RATIO_REGULAR_PACKETS: u32 = 3;
+
+const SIMD_PACKET_SIZE: u32 =
+    ((MTU_SIZE as u32 - LVErasureInformation::no_bytes() as u32 + 63) / 64) * 64;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct LVErasureInformation {

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -4,8 +4,8 @@ use bytes::BufMut;
 use log::trace;
 
 pub const MTU_SIZE: usize = 1200;
-pub const EC_RATIO_RECOVERY_PACKETS: u32 = 1;
-pub const EC_RATIO_REGULAR_PACKETS: u32 = 3;
+pub const EC_RATIO_RECOVERY_PACKETS: u32 = 2;
+pub const EC_RATIO_REGULAR_PACKETS: u32 = 4;
 
 pub const SIMD_PACKET_SIZE: u32 =
     ((MTU_SIZE as u32 - LVErasureInformation::no_bytes() as u32 + 63) / 64) * 64;

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -1,19 +1,57 @@
+use std::mem::size_of;
+
+use bytes::BufMut;
+use log::trace;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct LVPacket<'a> {
+pub struct LVErasureInformation {
     // Every block will have a unique error correcting ID.
     // This will allow us to know which packets go with which blocks.
     pub block_id: u32,
     // The minimum number of fragments that are required in this fragment sequence
     // to decode the full thing
-    pub min_fragment_size: usize,
+    pub min_fragment_size: u32,
     // Allows us to determine if recovery packet or not, which is required for decoding
     pub recovery_pkt: bool,
     // Required for the decoding as well --- used to determine the # of the recovery
     // or regular packet (I would imagine that this is for polynomial interpolation or something)
     pub fragment_index: u32,
-    // Given length of data
-    pub payload_len: usize,
-    // Actual data
-    pub payload: &'a [u8],
+}
+
+impl LVErasureInformation {
+    pub fn no_bytes() -> usize {
+        3 * size_of::<u32>() + size_of::<bool>()
+    }
+
+    pub fn to_bytes(self, mut buf: &mut [u8]) {
+        let mut i = 0;
+        for byt in self.block_id.to_be_bytes() {
+            buf[i] = byt;
+            i += 1;
+        }
+
+        for byt in self.min_fragment_size.to_be_bytes() {
+            buf[i] = byt;
+            i += 1;
+        }
+
+        buf.put_u8(self.recovery_pkt as u8);
+        i += 1;
+
+        for byt in self.fragment_index.to_be_bytes() {
+            buf[i] = byt;
+            i += 1;
+        }
+        trace!("now buf is {:?}", buf);
+    }
+
+    pub fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            block_id: u32::from_be_bytes(buf[0..4].try_into().unwrap()),
+            min_fragment_size: u32::from_be_bytes(buf[4..8].try_into().unwrap()),
+            recovery_pkt: buf[9] != 0,
+            fragment_index: u32::from_be_bytes(buf[9..13].try_into().unwrap()),
+        }
+    }
 }

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -3,11 +3,11 @@ use std::mem::size_of;
 use bytes::BufMut;
 use log::trace;
 
-const MTU_SIZE: usize = 1200;
-const EC_RATIO_RECOVERY_PACKETS: u32 = 1;
-const EC_RATIO_REGULAR_PACKETS: u32 = 3;
+pub const MTU_SIZE: usize = 1200;
+pub const EC_RATIO_RECOVERY_PACKETS: u32 = 1;
+pub const EC_RATIO_REGULAR_PACKETS: u32 = 3;
 
-const SIMD_PACKET_SIZE: u32 =
+pub const SIMD_PACKET_SIZE: u32 =
     ((MTU_SIZE as u32 - LVErasureInformation::no_bytes() as u32 + 63) / 64) * 64;
 
 #[repr(C)]

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -1,0 +1,19 @@
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct LVPacket<'a> {
+    // Every block will have a unique error correcting ID.
+    // This will allow us to know which packets go with which blocks.
+    pub block_id: u32,
+    // The minimum number of fragments that are required in this fragment sequence
+    // to decode the full thing
+    pub min_fragment_size: usize,
+    // Allows us to determine if recovery packet or not, which is required for decoding
+    pub recovery_pkt: bool,
+    // Required for the decoding as well --- used to determine the # of the recovery
+    // or regular packet (I would imagine that this is for polynomial interpolation or something)
+    pub fragment_index: u32,
+    // Given length of data
+    pub payload_len: usize,
+    // Actual data
+    pub payload: &'a [u8],
+}

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -24,13 +24,22 @@ pub struct LVErasureInformation {
     // Required for the decoding as well --- used to determine the # of the recovery
     // or regular packet (I would imagine that this is for polynomial interpolation or something)
     pub fragment_index: u32,
+    // For the recovery packet: store the packet sizes for the other regular packets
+    // so we know how much to truncate after using the SIMD decoder.
+    //
+    // We can store this as a u16 because the largest packet size over UDP can be stored as a u16 value.
+    pub pkt_sizes: [u16; EC_RATIO_REGULAR_PACKETS as usize],
 }
 
 impl LVErasureInformation {
     pub const fn no_bytes() -> usize {
-        3 * size_of::<u32>() + size_of::<bool>()
+        3 * size_of::<u32>()
+            + size_of::<bool>()
+            + size_of::<[u16; EC_RATIO_REGULAR_PACKETS as usize]>()
     }
 
+    // TODO
+    // maybe don't use big endian. it's prolly faster.
     pub fn to_bytes(self, buf: &mut [u8]) {
         let mut i = 0;
         for byt in self.block_id.to_be_bytes() {
@@ -50,15 +59,34 @@ impl LVErasureInformation {
             buf[i] = byt;
             i += 1;
         }
+
+        for pksz in self.pkt_sizes {
+            for byt in pksz.to_be_bytes() {
+                buf[i] = byt;
+                i += 1;
+            }
+        }
         trace!("now buf is {:?}", buf);
     }
 
     pub fn from_bytes(buf: &[u8]) -> Self {
+        // not a huge fan of this.
+        let mut pkt_sizes: [u16; EC_RATIO_REGULAR_PACKETS as usize] =
+            [0; EC_RATIO_REGULAR_PACKETS as usize];
+        for i in 0..EC_RATIO_REGULAR_PACKETS {
+            pkt_sizes[i as usize] = u16::from_be_bytes(
+                buf[(13 + (i * 2) as usize)..(15 + (i * 2) as usize)]
+                    .try_into()
+                    .unwrap(),
+            );
+        }
+
         Self {
             block_id: u32::from_be_bytes(buf[0..4].try_into().unwrap()),
             min_fragment_size: u32::from_be_bytes(buf[4..8].try_into().unwrap()),
             recovery_pkt: buf[9] != 0,
             fragment_index: u32::from_be_bytes(buf[9..13].try_into().unwrap()),
+            pkt_sizes,
         }
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,10 +36,12 @@ nvidia-video-codec-sdk = { path = "../nvidia-video-codec-sdk", optional=true }
 # Package
 rtp = "0.9.0"
 webrtc-util = "0.8"
-reed-solomon-novelpoly = "1.0.2"
+reed-solomon-simd = "2.2"
 bytes = "1"
 ring = "0.17.5"
 rand = "0.8"
+bytemuck = "1"
+lazy_static = "1"
 
 # Logging
 log = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,7 +40,7 @@ reed-solomon-simd = "2.2"
 bytes = "1"
 ring = "0.17.5"
 rand = "0.8"
-bytemuck = "1"
+bytemuck = { version = "1", features=["derive", "min_const_generics"] }
 lazy_static = "1"
 
 # Logging

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -57,3 +57,6 @@ flume = "0.11"
 
 # Statistics
 statistics = { path = "../statistics" }
+
+# Shared packets
+net = { path = "../net" }

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -55,7 +55,7 @@ impl LVPackager {
 
         Ok(Self {
             encoder,
-            // TODO: Default??
+            // TODO: Default?       ?
             h264_bitstream_writer: BytesMut::new().writer(),
             rtp_queue: VecDeque::new(),
             yuv_buffer: YUVBuffer::new(width, height),
@@ -144,10 +144,12 @@ impl LVPackager {
         target_addr: &str,
     ) -> Result<usize, Box<dyn std::error::Error>> {
         if let Some(pkt) = self.rtp_queue.pop_back() {
-            self.erasure_manager
-                .send_lv_packet(socket, target_addr, &pkt.payload, false)?;
+            return self
+                .erasure_manager
+                .send_lv_packet(socket, target_addr, &pkt.payload, false);
+        } else {
+            Ok(0)
         }
-        Ok(0)
     }
 
     // Get the next RTP packet to send over the network

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -152,7 +152,7 @@ impl LVPackager {
 
     // Get the next RTP packet to send over the network
     pub fn has_rtp(&mut self) -> bool {
-        self.rtp_queue.is_empty()
+        !self.rtp_queue.is_empty()
     }
 
     // pub fn encrypt();

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, fs::File, io::Write, time::Instant};
+use std::{collections::VecDeque, fs::File, io::Write, net::UdpSocket, time::Instant};
 
 use bytes::{buf::Writer, BufMut, Bytes, BytesMut};
 use dcv_color_primitives::{convert_image, get_buffers_size, ColorSpace, ImageFormat};
@@ -19,6 +19,8 @@ use statistics::{
 };
 
 use crate::encoder::LVEncoder;
+
+pub mod packet;
 
 const MTU_SIZE: usize = 1200;
 const SAMPLE_RATE: u32 = 90000;
@@ -116,6 +118,10 @@ impl LVPackager {
         for payload in payloads {
             // Marshal into RTP.
             trace!("packet payload data: {:?}", &payload.payload.as_ref());
+            trace!(
+                "packet payload data len {}",
+                &payload.payload.as_ref().len()
+            );
             self.rtp_queue.push_front(payload);
             packet_count += 1;
         }
@@ -127,6 +133,9 @@ impl LVPackager {
 
         Ok(())
     }
+
+    pub fn send_next_pkt(&mut self, socket: &mut UdpSocket, target_addr: &str) {}
+
     // Get the next RTP packet to send over the network
     pub fn pop_rtp(&mut self) -> Option<Packet> {
         self.rtp_queue.pop_back()

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -26,7 +26,6 @@ use self::packet::LVErasureManager;
 
 pub mod packet;
 
-const MTU_SIZE: usize = 1200;
 const SAMPLE_RATE: u32 = 90000;
 
 // TODO update the error handling

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -150,7 +150,7 @@ impl LVPackager {
         if let Some(pkt) = self.rtp_queue.pop_back() {
             return self
                 .erasure_manager
-                .send_lv_packet(socket, target_addr, pkt, false);
+                .send_lv_packet(socket, target_addr, pkt);
         } else {
             Ok(0)
         }

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -148,11 +148,9 @@ impl LVPackager {
         target_addr: &str,
     ) -> Result<usize, Box<dyn std::error::Error>> {
         if let Some(pkt) = self.rtp_queue.pop_back() {
-            self.rtp_pkt.resize(pkt.marshal_size(), 0);
-            pkt.marshal_to(&mut self.rtp_pkt)?;
             return self
                 .erasure_manager
-                .send_lv_packet(socket, target_addr, &self.rtp_pkt, false);
+                .send_lv_packet(socket, target_addr, pkt, false);
         } else {
             Ok(0)
         }

--- a/server/src/packager/mod.rs
+++ b/server/src/packager/mod.rs
@@ -4,7 +4,7 @@ use bytes::{buf::Writer, BufMut, Bytes, BytesMut};
 use dcv_color_primitives::{convert_image, get_buffers_size, ColorSpace, ImageFormat};
 use image::{ImageBuffer, Rgb};
 use log::{debug, trace};
-use net::packet::LVErasureInformation;
+use net::packet::{LVErasureInformation, MTU_SIZE};
 use openh264::formats::{YUVBuffer, YUVSource};
 use rand::Rng;
 use rtp::{

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -19,12 +19,6 @@ use super::MTU_SIZE;
 
 // TODO: Don't we want a packet size?
 
-const EC_RATIO_RECOVERY_PACKETS: u32 = 1;
-const EC_RATIO_REGULAR_PACKETS: u32 = 3;
-
-const SIMD_PACKET_SIZE: u32 =
-    ((MTU_SIZE as u32 - LVErasureInformation::no_bytes() as u32 + 63) / 64) * 64;
-
 pub struct LVErasureManager {
     enc: ReedSolomonEncoder,
     current_block_id: u32,

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -70,6 +70,10 @@ impl LVErasureManager {
             (self.current_regular_fragment_index + 1) % EC_RATIO_REGULAR_PACKETS;
 
         if self.current_regular_fragment_index == 0 {
+            self.current_block_id += 1;
+        }
+
+        if self.current_regular_fragment_index == 1 {
             debug!("obtaining recovery data from reed solomon code");
 
             self.current_recovery_fragment_index =
@@ -110,8 +114,6 @@ impl LVErasureManager {
             debug!("send {} RECOVERY bytes to {}", bytes, target_addr);
 
             self.largest_sized_payload = 0;
-
-            self.current_block_id += 1;
         }
 
         let marshal_size = rtp.marshal_size();

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -7,6 +7,7 @@
 
 use bytes::Bytes;
 use lazy_static::lazy_static;
+use log::debug;
 use reed_solomon_simd::ReedSolomonEncoder;
 use std::{net::UdpSocket, ops::Index, slice::SliceIndex};
 
@@ -68,6 +69,8 @@ impl LVErasureManager {
                 ::core::mem::size_of::<LVPacket>(),
             )
         };
+
+        debug!("sent lv packet as {:?}", pk_pay);
 
         Ok(socket.send_to(pk_pay, target_addr)?)
     }

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -22,13 +22,15 @@ use super::MTU_SIZE;
 const EC_RATIO_RECOVERY_PACKETS: u32 = 1;
 const EC_RATIO_REGULAR_PACKETS: u32 = 3;
 
-const SIMD_PACKET_SIZE: u32 = ((MTU_SIZE as u32 + 63) / 64) * 64;
+const SIMD_PACKET_SIZE: u32 =
+    ((MTU_SIZE as u32 - LVErasureInformation::no_bytes() as u32 + 63) / 64) * 64;
 
 pub struct LVErasureManager {
     enc: ReedSolomonEncoder,
     current_block_id: u32,
     current_regular_fragment_index: u32,
     current_recovery_fragment_index: u32,
+    largest_sized_payload: usize,
     pkt_data: BytesMut,
 }
 
@@ -43,6 +45,7 @@ impl LVErasureManager {
             current_block_id: 0,
             current_regular_fragment_index: 0,
             current_recovery_fragment_index: 0,
+            largest_sized_payload: 0,
             pkt_data: BytesMut::zeroed(
                 SIMD_PACKET_SIZE as usize + LVErasureInformation::no_bytes(),
             ),
@@ -58,15 +61,12 @@ impl LVErasureManager {
         socket: &UdpSocket,
         target_addr: &str,
         rtp: Packet,
-        recovery_pkt: bool,
     ) -> Result<usize, Box<dyn std::error::Error>> {
-        // self.enc.add_original_shard(payload)?;
-
         let pk = LVErasureInformation {
             block_id: self.current_block_id,
             fragment_index: self.current_regular_fragment_index,
             min_fragment_size: EC_RATIO_REGULAR_PACKETS,
-            recovery_pkt,
+            recovery_pkt: false,
         };
 
         trace!("lv erasure information {:?}", pk);
@@ -76,10 +76,54 @@ impl LVErasureManager {
             (self.current_regular_fragment_index + 1) % EC_RATIO_REGULAR_PACKETS;
 
         if self.current_regular_fragment_index == 0 {
+            debug!("obtaining recovery data from reed solomon code");
+
+            self.current_recovery_fragment_index =
+                (self.current_recovery_fragment_index + 1) % EC_RATIO_RECOVERY_PACKETS;
+
+            let recovery_payload = self.enc.encode()?;
+            let recovery_header = LVErasureInformation {
+                block_id: self.current_block_id,
+                fragment_index: self.current_recovery_fragment_index,
+                min_fragment_size: EC_RATIO_REGULAR_PACKETS,
+                recovery_pkt: true,
+            };
+
+            debug!("recovery header is {:?}", recovery_header);
+
+            recovery_header.to_bytes(&mut self.pkt_data);
+
+            for recovery_pkt in recovery_payload.recovery_iter() {
+                let pkt_slice = &mut self.pkt_data[(LVErasureInformation::no_bytes())
+                    ..(LVErasureInformation::no_bytes() + self.largest_sized_payload)];
+
+                debug!("largest sized payload was {}", self.largest_sized_payload);
+                debug!("recovery payload is {:?}", recovery_pkt);
+
+                // RS recovery packet will not have payload larger than largest sized RTP packet,
+                // so we can just slice the array as 0..self.largest_sized_payload
+
+                pkt_slice.copy_from_slice(&recovery_pkt[0..self.largest_sized_payload]);
+            }
+
+            // send recovery packet over network
+
+            let send_slice =
+                &self.pkt_data[..(self.largest_sized_payload + LVErasureInformation::no_bytes())];
+
+            debug!("send slice is {:?}", send_slice);
+            let bytes = socket.send_to(send_slice, target_addr)?;
+            debug!("send {} RECOVERY bytes to {}", bytes, target_addr);
+
+            self.largest_sized_payload = 0;
+
             self.current_block_id += 1;
         }
 
         let marshal_size = rtp.marshal_size();
+        if marshal_size > self.largest_sized_payload {
+            self.largest_sized_payload = marshal_size;
+        }
 
         trace!(
             "size of bytes of erasure information is {}",
@@ -93,10 +137,22 @@ impl LVErasureManager {
         // trace!("payload is {:?}", payload);
 
         pk.to_bytes(&mut self.pkt_data);
-        rtp.marshal_to(
-            &mut self.pkt_data[(LVErasureInformation::no_bytes())
-                ..(LVErasureInformation::no_bytes() + marshal_size)],
-        );
+
+        {
+            let mut rtp_slice = &mut self.pkt_data[(LVErasureInformation::no_bytes())
+                ..(LVErasureInformation::no_bytes() + marshal_size)];
+            rtp.marshal_to(&mut rtp_slice)?;
+
+            // zero out the data that wasn't written to ):
+            // TODO can we make this any more efficient?
+            // because the trade off is if I don't do this,
+            // we send more data which is useless,
+            // but then if I do this it takes more time.
+            self.pkt_data[(LVErasureInformation::no_bytes() + marshal_size)..].fill(0);
+
+            self.enc
+                .add_original_shard(&self.pkt_data[LVErasureInformation::no_bytes()..])?;
+        }
 
         let send_slice = &self.pkt_data[0..(LVErasureInformation::no_bytes() + marshal_size)];
         debug!("sent lv packet as {:?}", send_slice);

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -13,9 +13,9 @@ use rtp::packet::Packet;
 use std::{net::UdpSocket, ops::Index, slice::SliceIndex, time::SystemTime};
 use webrtc_util::{Marshal, MarshalSize};
 
-use net::packet::LVErasureInformation;
-
-use super::MTU_SIZE;
+use net::packet::{
+    LVErasureInformation, EC_RATIO_RECOVERY_PACKETS, EC_RATIO_REGULAR_PACKETS, SIMD_PACKET_SIZE,
+};
 
 // TODO: Don't we want a packet size?
 

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -10,6 +10,8 @@ use lazy_static::lazy_static;
 use reed_solomon_simd::ReedSolomonEncoder;
 use std::{net::UdpSocket, ops::Index, slice::SliceIndex};
 
+use net::packet::LVPacket;
+
 use super::MTU_SIZE;
 
 // TODO: Don't we want a packet size?
@@ -49,6 +51,8 @@ impl LVErasureManager {
         payload: &[u8],
         recovery_pkt: bool,
     ) -> Result<usize, Box<dyn std::error::Error>> {
+        // self.enc.add_original_shard(payload)?;
+
         let pk = LVPacket {
             block_id: self.current_block_id,
             fragment_index: self.current_fragment_index,
@@ -67,24 +71,4 @@ impl LVErasureManager {
 
         Ok(socket.send_to(pk_pay, target_addr)?)
     }
-}
-
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct LVPacket<'a> {
-    // Every block will have a unique error correcting ID.
-    // This will allow us to know which packets go with which blocks.
-    block_id: u32,
-    // The minimum number of fragments that are required in this fragment sequence
-    // to decode the full thing
-    min_fragment_size: usize,
-    // Allows us to determine if recovery packet or not, which is required for decoding
-    recovery_pkt: bool,
-    // Required for the decoding as well --- used to determine the # of the recovery
-    // or regular packet (I would imagine that this is for polynomial interpolation or something)
-    fragment_index: u32,
-    // Given length of data
-    payload_len: usize,
-    // Actual data
-    payload: &'a [u8],
 }

--- a/server/src/packager/packet.rs
+++ b/server/src/packager/packet.rs
@@ -1,0 +1,104 @@
+// A packet is a unit of data that is sent over the network.
+// When we receive a RTP packet, we split it into CHUNK_SIZE-byte chunks.
+//
+// Note the CHUNK_SIZE is given as ceil(PKT_SIZE // EC_RATIO_REGULAR_PACKETS) rounded up to the nearest multiple of 64.
+//
+// We then use the error-correcting code library to generate exactly EC_RATIO_RECOVERY_PACKETS packets,
+
+use bytes::Bytes;
+use lazy_static::lazy_static;
+use reed_solomon_simd::ReedSolomonEncoder;
+use std::{net::UdpSocket, ops::Index, slice::SliceIndex};
+
+use super::MTU_SIZE;
+
+// TODO: Don't we want a packet size?
+
+const EC_RATIO_RECOVERY_PACKETS: usize = 1;
+const EC_RATIO_REGULAR_PACKETS: usize = 3;
+
+const SIMD_PACKET_SIZE: usize = ((MTU_SIZE + 63) / 64) * 64;
+
+pub struct LVErasureManager {
+    enc: ReedSolomonEncoder,
+    current_block_id: u32,
+    current_fragment_index: u32,
+}
+
+impl LVErasureManager {
+    fn init() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            enc: ReedSolomonEncoder::new(
+                EC_RATIO_REGULAR_PACKETS,
+                EC_RATIO_RECOVERY_PACKETS,
+                SIMD_PACKET_SIZE,
+            )?,
+            current_block_id: 0,
+            current_fragment_index: 0,
+        })
+    }
+
+    // Given an input packet,
+    // return a pair, where the first packet is the payload given as an LVPacket and
+    // the second packet is an Option<LVPacket> that contains recovery data
+    // if the encoder gave us some.
+    fn send_lv_packet(
+        &mut self,
+        socket: &mut UdpSocket,
+        target_addr: &str,
+        payload: &[u8],
+        recovery_pkt: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let pk = LVPacket {
+            block_id: self.current_block_id,
+            fragment_index: self.current_fragment_index,
+            min_fragment_size: EC_RATIO_REGULAR_PACKETS,
+            recovery_pkt,
+            payload_len: payload.len(),
+            payload,
+        };
+
+        socket.send_to(bytemuck::bytes_of(&pk), target_addr);
+
+        Ok(())
+    }
+
+    fn send_pkts_over_network() {}
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, bytemuck::NoUninit, Copy)]
+pub struct LVPacket<'a> {
+    // Every block will have a unique error correcting ID.
+    // This will allow us to know which packets go with which blocks.
+    block_id: u32,
+    // The minimum number of fragments that are required in this fragment sequence
+    // to decode the full thing
+    min_fragment_size: usize,
+    // Allows us to determine if recovery packet or not, which is required for decoding
+    recovery_pkt: bool,
+    // Required for the decoding as well --- used to determine the # of the recovery
+    // or regular packet (I would imagine that this is for polynomial interpolation or something)
+    fragment_index: u32,
+    // Given length of data
+    payload_len: usize,
+    // Actual data
+    payload: &'a [u8],
+}
+
+/*pub struct JoinedArray {
+    slice_left: Bytes,
+    slice_right: Bytes,
+}
+
+impl Index<usize> for JoinedArray {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &u8 {
+        if index < self.slice_left.len() {
+            &self.slice_left[index]
+        } else {
+            &self.slice_right[index - self.slice_left.len()]
+        }
+    }
+}*/

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -138,18 +138,8 @@ impl Server {
             }
 
             let loop_pkg = Instant::now();
-            while let Some(rtp) = packager.pop_rtp() {
-                rtp_pkt.resize(rtp.marshal_size(), 0);
-                debug!("rtp_pkt capacity {}", rtp_pkt.capacity());
-                debug!("rtp_pkt len {}", rtp_pkt.len());
-                debug!(
-                    "rtp_pkt remaining_mut before {} and marshal_size {}",
-                    (&mut rtp_pkt).remaining_mut(),
-                    rtp.marshal_size()
-                );
-                debug!("rtp_pkt remaining_mut after {}", rtp_pkt.remaining_mut());
-                rtp.marshal_to(&mut rtp_pkt)?;
-                match socket.send_to(&rtp_pkt, &self.target_addr) {
+            while packager.has_rtp() {
+                match packager.send_next_pkt(&socket, &self.target_addr) {
                     Ok(bytes) => debug!("sent {} bytes to addr", bytes),
                     Err(e) => error!("send_to returned {:?}", e),
                 }


### PR DESCRIPTION
This adds error correction with an adjustable ratio of source:recovery packets using Reed Solomon erasure codes. 

The current layout of packets sent to the client is:

```
S S S R R
```

So all source packets are sent first, then all recovery packets. This is for latency reasons. If we wanted to interleave the recovery packets, then we would have to wait for all source packets per ratio to be sent to the encoder, then receive the recovery packets, then send the interleaved packets. However, in this scheme, we can send the source packets immediately, i.e. when they have been produced, which can theoretically decrease latency.